### PR TITLE
Fix WeekRow children typing

### DIFF
--- a/src/date-picker/week-row.jsx
+++ b/src/date-picker/week-row.jsx
@@ -6,7 +6,7 @@ import {Row} from "../table"
 
 export default memo(shapeComponent(class WeekRow extends ShapeComponent {
   static propTypes = propTypesExact({
-    children: PropTypes.node,
+    children: PropTypes.any,
     dataSet: PropTypes.object,
     mode: PropTypes.oneOf(["date", "dateRange", "week"]).isRequired,
     onClick: PropTypes.func,
@@ -65,7 +65,9 @@ export default memo(shapeComponent(class WeekRow extends ShapeComponent {
         onPointerLeave={this.tt.onPointerLeave}
         style={style}
         {...restProps}
-      />
+      >
+        {this.props.children}
+      </Row>
     )
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+export {default} from "./date-picker/index"


### PR DESCRIPTION
## Summary
- allow any React children in WeekRow to avoid prop-type warnings
- add package entrypoint index to satisfy main resolution

## Testing
- not run (library change only)