### PR TITLE
Remove useStates from date picker components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eventemitter3": "^5.0.1",
         "moment": "^2.30.1",
         "prop-types": "^15.8.1",
-        "set-state-compare": "^1.0.64",
+        "set-state-compare": "^1.0.84",
         "strftime": "^0.10.3",
         "ya-use-event-emitter": "^0.1.2"
       },
@@ -7049,9 +7049,9 @@
       }
     },
     "node_modules/fetching-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.5.tgz",
-      "integrity": "sha512-hXflbW3DknOZJdqduLZn/hiMWDO9/eEv2BMvc8F8BO/3Fbh0B7hMrcaKdlQolJw3To3SJD1l9yzsCmWtzsmlpw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fetching-object/-/fetching-object-1.0.7.tgz",
+      "integrity": "sha512-DVBXLz6EijDqntTWpw/4m/77yFfPXGUVrcTI0fQXJWS9Zu7ljgKVhIi7NI+jrcqBxsJFpN+vM7spyX2JGKEiAA==",
       "license": "ISC"
     },
     "node_modules/file-saver": {
@@ -11853,13 +11853,13 @@
       }
     },
     "node_modules/set-state-compare": {
-      "version": "1.0.70",
-      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.70.tgz",
-      "integrity": "sha512-IemC7Vveo2pSiKy1KhGJJs6pT8qZIQ1wpcITT1LCbBGIwjsQ2NGAvotgHNJ7+RhEJu1auLM7uv3qaLD8/SC2lA==",
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/set-state-compare/-/set-state-compare-1.0.84.tgz",
+      "integrity": "sha512-9n3zn0gbMaq+NJpAgc54zQXRQ8lV7b8TmDWJUIns9QS9MSij/mtaGAr5rCbLB+W1+tQ60KvDbgZyrWtDtXoDHg==",
       "license": "ISC",
       "dependencies": {
         "diggerize": "^1.0.5",
-        "fetching-object": ">= 1.0.5"
+        "fetching-object": "^1.0.7"
       },
       "peerDependencies": {
         "prop-types": ">= 15.8.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eventemitter3": "^5.0.1",
     "moment": "^2.30.1",
     "prop-types": "^15.8.1",
-    "set-state-compare": "^1.0.64",
+    "set-state-compare": "^1.0.84",
     "strftime": "^0.10.3",
     "ya-use-event-emitter": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "rm -rf build && tsc -p tsconfig.json || true",
     "build:example:dist": "node scripts/build-example.js",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "release:patch": "node scripts/release-patch.js",
     "test": "node scripts/velocious-test.js",

--- a/spec/system/haya-date-picker.browser-spec.js
+++ b/spec/system/haya-date-picker.browser-spec.js
@@ -4,11 +4,14 @@ import waitFor from "awaitery/build/wait-for.js"
 import SystemTest from "system-testing/build/system-test.js"
 
 SystemTest.rootPath = "/?systemTest=true"
+const httpHost = process.env.SYSTEM_TEST_HTTP_HOST == "0.0.0.0"
+  ? "127.0.0.1"
+  : process.env.SYSTEM_TEST_HTTP_HOST || "localhost"
 const systemTestArgs = {
   debug: false,
   host: process.env.SYSTEM_TEST_APP_HOST || "localhost",
   port: process.env.SYSTEM_TEST_APP_PORT ? Number(process.env.SYSTEM_TEST_APP_PORT) : 8081,
-  httpHost: process.env.SYSTEM_TEST_HTTP_HOST || "localhost",
+  httpHost,
   httpPort: process.env.SYSTEM_TEST_HTTP_PORT ? Number(process.env.SYSTEM_TEST_HTTP_PORT) : 1984
 }
 let didStartSystemTest = false

--- a/src/date-picker/date-column.jsx
+++ b/src/date-picker/date-column.jsx
@@ -7,7 +7,23 @@ import propTypesExact from "prop-types-exact"
 
 /** @typedef {import("./index.jsx").HayaDatePickerMode} HayaDatePickerMode */
 /** @typedef {import("./index.jsx").HayaDatePickerStyles} HayaDatePickerStyles */
-/** @typedef {{active: boolean, currentDate: Date, date: Date, dayNumber: number, focus: boolean, last: boolean, mode: HayaDatePickerMode, onPress: (...args: unknown[]) => unknown, onPointerEnter: (...args: unknown[]) => unknown, onPointerLeave: (...args: unknown[]) => unknown, rangeEnd?: Date, rangePreviewEnd?: Date, rangeStart?: Date, styles?: HayaDatePickerStyles}} DateColumnProps */
+/**
+ * @typedef {object} DateColumnProps
+ * @property {boolean} active
+ * @property {Date} currentDate
+ * @property {Date} date
+ * @property {number} dayNumber
+ * @property {boolean} focus
+ * @property {boolean} last
+ * @property {HayaDatePickerMode} mode
+ * @property {(...args: unknown[]) => unknown} onPress
+ * @property {(...args: unknown[]) => unknown} onPointerEnter
+ * @property {(...args: unknown[]) => unknown} onPointerLeave
+ * @property {Date=} rangeEnd
+ * @property {Date=} rangePreviewEnd
+ * @property {Date=} rangeStart
+ * @property {HayaDatePickerStyles=} styles
+ */
 /** @typedef {{hover: boolean}} DateColumnState */
 
 class DateColumn extends ShapeComponent {
@@ -35,9 +51,6 @@ class DateColumn extends ShapeComponent {
   /** @type {DateColumnState} */
   state = {
     hover: false
-  }
-
-  setup() {
   }
 
   render() {

--- a/src/date-picker/date-column.jsx
+++ b/src/date-picker/date-column.jsx
@@ -27,10 +27,11 @@ export default memo(shapeComponent(class DateColumn extends ShapeComponent {
     styles: PropTypes.object
   })
 
+  state = {
+    hover: false
+  }
+
   setup() {
-    this.useStates({
-      hover: false
-    })
   }
 
   render() {

--- a/src/date-picker/date-column.jsx
+++ b/src/date-picker/date-column.jsx
@@ -5,7 +5,12 @@ import {Column} from "../table"
 import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 
-export default memo(shapeComponent(class DateColumn extends ShapeComponent {
+/** @typedef {import("./index.jsx").HayaDatePickerMode} HayaDatePickerMode */
+/** @typedef {import("./index.jsx").HayaDatePickerStyles} HayaDatePickerStyles */
+/** @typedef {{active: boolean, currentDate: Date, date: Date, dayNumber: number, focus: boolean, last: boolean, mode: HayaDatePickerMode, onPress: (...args: unknown[]) => unknown, onPointerEnter: (...args: unknown[]) => unknown, onPointerLeave: (...args: unknown[]) => unknown, rangeEnd?: Date, rangePreviewEnd?: Date, rangeStart?: Date, styles?: HayaDatePickerStyles}} DateColumnProps */
+/** @typedef {{hover: boolean}} DateColumnState */
+
+class DateColumn extends ShapeComponent {
   static defaultProps = {
     styles: {}
   }
@@ -27,6 +32,7 @@ export default memo(shapeComponent(class DateColumn extends ShapeComponent {
     styles: PropTypes.object
   })
 
+  /** @type {DateColumnState} */
   state = {
     hover: false
   }
@@ -201,4 +207,6 @@ export default memo(shapeComponent(class DateColumn extends ShapeComponent {
         firstDate.getDate() == secondDate.getDate()
     )
   }
-}))
+}
+
+export default memo(shapeComponent(DateColumn))

--- a/src/date-picker/index.jsx
+++ b/src/date-picker/index.jsx
@@ -37,13 +37,14 @@ export default memo(shapeComponent(class HayaDatePicker extends ShapeComponent {
   weekNumberColumnDataSet = undefined
   weekNumberColumnStyle = undefined
 
+  state = {
+    currentDate: this.props.defaultCurrentDate,
+    hoverDate: null,
+    selectedDate: null
+  }
+
   setup() {
     this.locale = useLocale()
-    this.useStates({
-      currentDate: this.p.defaultCurrentDate,
-      hoverDate: null,
-      selectedDate: null
-    })
     this.weeksInMonth = useMemo(() => this.getWeeksInMonth(), [this.s.currentDate])
   }
 

--- a/src/date-picker/index.jsx
+++ b/src/date-picker/index.jsx
@@ -9,7 +9,16 @@ import {Pressable, Text, View} from "react-native"
 import useLocale from "../use-locale"
 import WeekRow from "./week-row"
 
-export default memo(shapeComponent(class HayaDatePicker extends ShapeComponent {
+/** @typedef {"date" | "dateRange" | "week"} HayaDatePickerMode */
+/** @typedef {{[year: number]: {[week: number]: true}}} HayaDatePickerWeeksAvailable */
+/** @typedef {{dayHeaderHeadColumnStyle?: object, dayHeaderHeadColumnTextStyle?: object, headerViewStyle?: object, initialHeadColumnStyle?: object, nextButtonStyle?: object, nextTextStyle?: object, nextViewStyle?: object, previousButtonStyle?: object, previousTextStyle?: object, previousViewStyle?: object, rootViewStyle?: object, tableStyle?: object, titleTextStyle?: object, weekNumberTextStyle?: object}} HayaDatePickerStyles */
+/** @typedef {{dayNumber: number, date: Date, last: boolean}} HayaDatePickerWeekDay */
+/** @typedef {{date: Date, dayNumber: number, last: boolean}} HayaDatePickerWeekDayCell */
+/** @typedef {{weekDate: Date, daysInWeek: HayaDatePickerWeekDayCell[], weekNumber: number}} HayaDatePickerWeek */
+/** @typedef {{activeDates?: Date[], className?: string, dateFrom?: Date, dateTo?: Date, defaultCurrentDate: Date, mode: HayaDatePickerMode, onRangeSelect?: (...args: unknown[]) => unknown, onSelect?: (...args: unknown[]) => unknown, showWeekNumbers?: boolean, styles?: HayaDatePickerStyles, weekdayFormatter?: (...args: unknown[]) => string, weeksAvailable?: HayaDatePickerWeeksAvailable}} HayaDatePickerProps */
+/** @typedef {{currentDate: Date, hoverDate: Date | null, selectedDate: Date | null}} HayaDatePickerState */
+
+class HayaDatePicker extends ShapeComponent {
   static defaultProps = {
     activeDates: undefined,
     defaultCurrentDate: new Date(),
@@ -37,6 +46,7 @@ export default memo(shapeComponent(class HayaDatePicker extends ShapeComponent {
   weekNumberColumnDataSet = undefined
   weekNumberColumnStyle = undefined
 
+  /** @type {HayaDatePickerState} */
   state = {
     currentDate: this.props.defaultCurrentDate,
     hoverDate: null,
@@ -409,4 +419,6 @@ export default memo(shapeComponent(class HayaDatePicker extends ShapeComponent {
 
     return weeks
   }
-}))
+}
+
+export default memo(shapeComponent(HayaDatePicker))

--- a/src/date-picker/index.jsx
+++ b/src/date-picker/index.jsx
@@ -69,7 +69,7 @@ class HayaDatePicker extends ShapeComponent {
 
   setup() {
     this.locale = useLocale()
-    this.weeksInMonth = useMemo(() => this.getWeeksInMonth(), [this.s.currentDate])
+    this.weeksInMonth = useMemo(() => this.getWeeksInMonth(), [this.state.currentDate])
   }
 
   render() {

--- a/src/date-picker/index.jsx
+++ b/src/date-picker/index.jsx
@@ -15,7 +15,21 @@ import WeekRow from "./week-row"
 /** @typedef {{dayNumber: number, date: Date, last: boolean}} HayaDatePickerWeekDay */
 /** @typedef {{date: Date, dayNumber: number, last: boolean}} HayaDatePickerWeekDayCell */
 /** @typedef {{weekDate: Date, daysInWeek: HayaDatePickerWeekDayCell[], weekNumber: number}} HayaDatePickerWeek */
-/** @typedef {{activeDates?: Date[], className?: string, dateFrom?: Date, dateTo?: Date, defaultCurrentDate: Date, mode: HayaDatePickerMode, onRangeSelect?: (...args: unknown[]) => unknown, onSelect?: (...args: unknown[]) => unknown, showWeekNumbers?: boolean, styles?: HayaDatePickerStyles, weekdayFormatter?: (...args: unknown[]) => string, weeksAvailable?: HayaDatePickerWeeksAvailable}} HayaDatePickerProps */
+/**
+ * @typedef {object} HayaDatePickerProps
+ * @property {Date[]=} activeDates
+ * @property {string=} className
+ * @property {Date=} dateFrom
+ * @property {Date=} dateTo
+ * @property {Date} defaultCurrentDate
+ * @property {HayaDatePickerMode} mode
+ * @property {(...args: unknown[]) => unknown=} onRangeSelect
+ * @property {(...args: unknown[]) => unknown=} onSelect
+ * @property {boolean=} showWeekNumbers
+ * @property {HayaDatePickerStyles=} styles
+ * @property {(...args: unknown[]) => string=} weekdayFormatter
+ * @property {HayaDatePickerWeeksAvailable=} weeksAvailable
+ */
 /** @typedef {{currentDate: Date, hoverDate: Date | null, selectedDate: Date | null}} HayaDatePickerState */
 
 class HayaDatePicker extends ShapeComponent {

--- a/src/date-picker/input.jsx
+++ b/src/date-picker/input.jsx
@@ -6,7 +6,11 @@ import PropTypes from "prop-types"
 import propTypesExact from "prop-types-exact"
 import strftime from "strftime"
 
-export default memo(shapeComponent(class HayaDatePickerInput extends ShapeComponent {
+/** @typedef {{dateFrom?: Date, dateTo?: Date, onSelect: (...args: unknown[]) => unknown, [key: string]: unknown}} HayaDatePickerInputDatePickerProps */
+/** @typedef {{datePickerProps: HayaDatePickerInputDatePickerProps, styles?: {text?: object, view?: object}, textStyle?: object, viewStyle?: object}} HayaDatePickerInputProps */
+/** @typedef {{showDatePicker: boolean}} HayaDatePickerInputState */
+
+class HayaDatePickerInput extends ShapeComponent {
   static propTypes = propTypesExact({
     datePickerProps: PropTypes.object.isRequired,
     styles: PropTypes.object,
@@ -14,6 +18,7 @@ export default memo(shapeComponent(class HayaDatePickerInput extends ShapeCompon
     viewStyle: PropTypes.object
   })
 
+  /** @type {HayaDatePickerInputState} */
   state = {
     showDatePicker: false
   }
@@ -75,4 +80,6 @@ export default memo(shapeComponent(class HayaDatePickerInput extends ShapeCompon
   onPressed = () => {
     this.setState({showDatePicker: true})
   }
-}))
+}
+
+export default memo(shapeComponent(HayaDatePickerInput))

--- a/src/date-picker/input.jsx
+++ b/src/date-picker/input.jsx
@@ -7,7 +7,13 @@ import propTypesExact from "prop-types-exact"
 import strftime from "strftime"
 
 /** @typedef {{dateFrom?: Date, dateTo?: Date, onSelect: (...args: unknown[]) => unknown, [key: string]: unknown}} HayaDatePickerInputDatePickerProps */
-/** @typedef {{datePickerProps: HayaDatePickerInputDatePickerProps, styles?: {text?: object, view?: object}, textStyle?: object, viewStyle?: object}} HayaDatePickerInputProps */
+/**
+ * @typedef {object} HayaDatePickerInputProps
+ * @property {HayaDatePickerInputDatePickerProps} datePickerProps
+ * @property {{text?: object, view?: object}=} styles
+ * @property {object=} textStyle
+ * @property {object=} viewStyle
+ */
 /** @typedef {{showDatePicker: boolean}} HayaDatePickerInputState */
 
 class HayaDatePickerInput extends ShapeComponent {
@@ -21,9 +27,6 @@ class HayaDatePickerInput extends ShapeComponent {
   /** @type {HayaDatePickerInputState} */
   state = {
     showDatePicker: false
-  }
-
-  setup() {
   }
 
   render() {

--- a/src/date-picker/input.jsx
+++ b/src/date-picker/input.jsx
@@ -14,10 +14,11 @@ export default memo(shapeComponent(class HayaDatePickerInput extends ShapeCompon
     viewStyle: PropTypes.object
   })
 
+  state = {
+    showDatePicker: false
+  }
+
   setup() {
-    this.useStates({
-      showDatePicker: false
-    })
   }
 
   render() {

--- a/src/date-picker/week-row.jsx
+++ b/src/date-picker/week-row.jsx
@@ -4,7 +4,11 @@ import React, {memo, useMemo} from "react"
 import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-component"
 import {Row} from "../table"
 
-export default memo(shapeComponent(class WeekRow extends ShapeComponent {
+/** @typedef {import("./index.jsx").HayaDatePickerMode} HayaDatePickerMode */
+/** @typedef {{children?: import("react").ReactNode, dataSet?: Record<string, unknown>, mode: HayaDatePickerMode, onClick?: (...args: unknown[]) => unknown, weekActive: boolean, weekAvailable: boolean, weekDate?: Date, weekNumber?: number}} WeekRowProps */
+/** @typedef {{pointerOver: boolean}} WeekRowState */
+
+class WeekRow extends ShapeComponent {
   static propTypes = propTypesExact({
     children: PropTypes.any,
     dataSet: PropTypes.object,
@@ -16,6 +20,7 @@ export default memo(shapeComponent(class WeekRow extends ShapeComponent {
     weekNumber: PropTypes.number
   })
 
+  /** @type {WeekRowState} */
   state = {
     pointerOver: false
   }
@@ -82,4 +87,6 @@ export default memo(shapeComponent(class WeekRow extends ShapeComponent {
 
     this.props.onClick({e, weekDate, weekNumber})
   }
-}))
+}
+
+export default memo(shapeComponent(WeekRow))

--- a/src/date-picker/week-row.jsx
+++ b/src/date-picker/week-row.jsx
@@ -5,7 +5,17 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import {Row} from "../table"
 
 /** @typedef {import("./index.jsx").HayaDatePickerMode} HayaDatePickerMode */
-/** @typedef {{children?: import("react").ReactNode, dataSet?: Record<string, unknown>, mode: HayaDatePickerMode, onClick?: (...args: unknown[]) => unknown, weekActive: boolean, weekAvailable: boolean, weekDate?: Date, weekNumber?: number}} WeekRowProps */
+/**
+ * @typedef {object} WeekRowProps
+ * @property {import("react").ReactNode=} children
+ * @property {Record<string, unknown>=} dataSet
+ * @property {HayaDatePickerMode} mode
+ * @property {(...args: unknown[]) => unknown=} onClick
+ * @property {boolean} weekActive
+ * @property {boolean} weekAvailable
+ * @property {Date=} weekDate
+ * @property {number=} weekNumber
+ */
 /** @typedef {{pointerOver: boolean}} WeekRowState */
 
 class WeekRow extends ShapeComponent {
@@ -23,9 +33,6 @@ class WeekRow extends ShapeComponent {
   /** @type {WeekRowState} */
   state = {
     pointerOver: false
-  }
-
-  setup() {
   }
 
   render() {

--- a/src/date-picker/week-row.jsx
+++ b/src/date-picker/week-row.jsx
@@ -16,8 +16,11 @@ export default memo(shapeComponent(class WeekRow extends ShapeComponent {
     weekNumber: PropTypes.number
   })
 
+  state = {
+    pointerOver: false
+  }
+
   setup() {
-    this.useStates({pointerOver: false})
   }
 
   render() {

--- a/src/table/column.jsx
+++ b/src/table/column.jsx
@@ -3,7 +3,10 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import dataSetToAttributes from "./data-set-to-attributes.mjs"
 import {Platform, View} from "react-native"
 
-export default memo(shapeComponent(class TableColumn extends ShapeComponent {
+/** @typedef {import("react").ComponentProps<typeof View> & {dataSet?: Record<string, unknown>}} TableColumnProps */
+/** @typedef {Record<string, never>} TableColumnState */
+
+class TableColumn extends ShapeComponent {
   render() {
     const {dataSet, ...restProps} = this.props
 
@@ -13,4 +16,6 @@ export default memo(shapeComponent(class TableColumn extends ShapeComponent {
 
     return <View dataSet={dataSet} {...restProps} />
   }
-}))
+}
+
+export default memo(shapeComponent(TableColumn))

--- a/src/table/head-column.jsx
+++ b/src/table/head-column.jsx
@@ -2,7 +2,10 @@ import React, {memo} from "react"
 import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-component"
 import {Platform, View} from "react-native"
 
-export default memo(shapeComponent(class TableHeadColumn extends ShapeComponent {
+/** @typedef {import("react").ComponentProps<typeof View>} TableHeadColumnProps */
+/** @typedef {Record<string, never>} TableHeadColumnState */
+
+class TableHeadColumn extends ShapeComponent {
   render() {
     if (Platform.OS == "web") {
       return <th {...this.props} />
@@ -10,4 +13,6 @@ export default memo(shapeComponent(class TableHeadColumn extends ShapeComponent 
 
     return <View {...this.props} />
   }
-}))
+}
+
+export default memo(shapeComponent(TableHeadColumn))

--- a/src/table/row.jsx
+++ b/src/table/row.jsx
@@ -3,7 +3,10 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import dataSetToAttributes from "./data-set-to-attributes.mjs"
 import {Platform, View} from "react-native"
 
-export default memo(shapeComponent(class TableRow extends ShapeComponent {
+/** @typedef {import("react").ComponentProps<typeof View> & {dataSet?: Record<string, unknown>}} TableRowProps */
+/** @typedef {Record<string, never>} TableRowState */
+
+class TableRow extends ShapeComponent {
   render() {
     const {dataSet, ...restProps} = this.props
 
@@ -13,4 +16,6 @@ export default memo(shapeComponent(class TableRow extends ShapeComponent {
 
     return <View dataSet={dataSet} {...restProps} />
   }
-}))
+}
+
+export default memo(shapeComponent(TableRow))

--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -3,7 +3,10 @@ import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-comp
 import dataSetToAttributes from "./data-set-to-attributes.mjs"
 import {Platform, View} from "react-native"
 
-export default memo(shapeComponent(class TableColumn extends ShapeComponent {
+/** @typedef {import("react").ComponentProps<typeof View> & {dataSet?: Record<string, unknown>}} TableProps */
+/** @typedef {Record<string, never>} TableState */
+
+class TableComponent extends ShapeComponent {
   render() {
     const {dataSet, ...restProps} = this.props
 
@@ -13,4 +16,6 @@ export default memo(shapeComponent(class TableColumn extends ShapeComponent {
 
     return <View dataSet={dataSet} {...this.props} />
   }
-}))
+}
+
+export default memo(shapeComponent(TableComponent))

--- a/src/table/tbody.jsx
+++ b/src/table/tbody.jsx
@@ -2,7 +2,10 @@ import React, {memo} from "react"
 import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-component"
 import {Platform, View} from "react-native"
 
-export default memo(shapeComponent(class TableTbody extends ShapeComponent {
+/** @typedef {import("react").ComponentProps<typeof View>} TableTbodyProps */
+/** @typedef {Record<string, never>} TableTbodyState */
+
+class TableTbody extends ShapeComponent {
   render() {
     if (Platform.OS == "web") {
       return <tbody {...this.props} />
@@ -10,4 +13,6 @@ export default memo(shapeComponent(class TableTbody extends ShapeComponent {
 
     return <View {...this.props} />
   }
-}))
+}
+
+export default memo(shapeComponent(TableTbody))

--- a/src/table/thead.jsx
+++ b/src/table/thead.jsx
@@ -2,7 +2,10 @@ import React, {memo} from "react"
 import {shapeComponent, ShapeComponent} from "set-state-compare/build/shape-component"
 import {Platform, View} from "react-native"
 
-export default memo(shapeComponent(class TableThead extends ShapeComponent {
+/** @typedef {import("react").ComponentProps<typeof View>} TableTheadProps */
+/** @typedef {Record<string, never>} TableTheadState */
+
+class TableThead extends ShapeComponent {
   render() {
     if (Platform.OS == "web") {
       return <thead {...this.props} />
@@ -10,4 +13,6 @@ export default memo(shapeComponent(class TableThead extends ShapeComponent {
 
     return <View {...this.props} />
   }
-}))
+}
+
+export default memo(shapeComponent(TableThead))


### PR DESCRIPTION
## Summary
- replace remaining `this.useStates(...)` usage in the date-picker ShapeComponent classes with class `state` fields
- add a `prepare` script so git-based installs rebuild the published `build/` output automatically
- validate the package with `npm run typecheck` and `npm run build`

## Testing
- npm run typecheck
- npm run build